### PR TITLE
Adding new parameter to override natural_keys for hub_key in hub macro

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ The Data vault objects can often depend directly on source data. If the source d
 | sources | a list of meta data for each source table for the hub | X |
 |  name | if the source is a DBT source then it must have a name field (`source(name, table)`) |   |
 |  table | the table part of a `source(name, table)` or a `ref(table)` | X |
+|  hub_key | *optional* parameter to override the natural_keys, i.e `natural_key + rec_src` |  |
 |  natural_keys | a list with the fields that are used as sources for the target natural keys | X |
 |  load_dts | the source column containing the ingestion time | X |
 |  rec_src | a string describing the source | X |

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ The Data vault objects can often depend directly on source data. If the source d
 | sources | a list of meta data for each source table for the hub | X |
 |  name | if the source is a DBT source then it must have a name field (`source(name, table)`) |   |
 |  table | the table part of a `source(name, table)` or a `ref(table)` | X |
-|  hub_key | *optional* parameter to override the natural_keys, i.e `natural_key + rec_src` |  |
+|  hub_key_override | *optional* parameter to override the hub_key mapping with a string, i.e `'natural_key + <string>'` |  |
 |  natural_keys | a list with the fields that are used as sources for the target natural keys | X |
 |  load_dts | the source column containing the ingestion time | X |
 |  rec_src | a string describing the source | X |

--- a/macros/deduplicate.sql
+++ b/macros/deduplicate.sql
@@ -15,7 +15,7 @@ FROM (
     q.*
     ,ROW_NUMBER() OVER(PARTITION BY {{ dedup_fields | join(', ') }} ORDER BY {{ order_field }} ASC) rn
   FROM (
-    {{- caller() | indent(4) }}
+    {{- caller() | indent(4) -}}
   ) q
   {%- if is_incremental() %}
   WHERE NOT EXISTS (

--- a/macros/hub.sql
+++ b/macros/hub.sql
@@ -9,10 +9,10 @@
 {% if not loop.first %}UNION ALL{% endif %}
 {% set src_table = source(src.name, src.table) if src.name else ref(src.table) -%}
 SELECT
-  {% if not src.hub_key -%}
+  {% if not src.hub_key_override -%}
   {{ dbt_datavault.make_key(src.natural_keys) }} AS {{ tgt.hub_key }}
   {% else -%}
-  {{ dbt_datavault.make_key(src.hub_key) }} AS {{ tgt.hub_key }}
+  {{ src.hub_key_override }} AS {{ tgt.hub_key }}
   {% endif -%}
   {% for src_natural_key, tgt_natural_key in zip(src.natural_keys, tgt.natural_keys) -%}
   ,{{ src_natural_key }} AS {{ tgt_natural_key }}

--- a/macros/link.sql
+++ b/macros/link.sql
@@ -5,8 +5,8 @@
 {% set all_fields = [tgt.link_key] + tgt.hub_keys + ['load_dts', 'rec_src'] -%}
 
 {% call dbt_datavault.deduplicate([tgt.link_key], all_fields, no_deduplication=tgt.no_deduplication) -%}
-{% for src in metadata.sources %}
-{% if not loop.first %}UNION ALL{% endif -%}
+{%- for src in metadata.sources -%}
+{% if not loop.first %}UNION ALL{% endif %}
 {% set src_table = source(src.name, src.table) if src.name else ref(src.table) -%}
 {% set src_flat_nks = src.hub_natural_keys | sum(start=[]) -%}
 SELECT
@@ -19,7 +19,7 @@ SELECT
 FROM
   {{ src_table }}
 {{ dbt_datavault.filter_and_incremental_code(src) }}
-{% endfor -%}
+{%- endfor -%}
 {% endcall %}
 {% endmacro %}
 

--- a/macros/satellite.sql
+++ b/macros/satellite.sql
@@ -5,7 +5,7 @@
 {% set all_fields = [tgt.hub_key, 'load_dts'] + tgt.attributes + ['rec_src'] -%}
 
 {%- call dbt_datavault.deduplicate([tgt.hub_key] + tgt.attributes, all_fields, no_deduplication=tgt.no_deduplication) %}
-{% for src in metadata.sources %}
+{%- for src in metadata.sources -%}
 {% if not loop.first %}UNION ALL{% endif %}
 {% set src_table = source(src.name, src.table) if src.name else ref(src.table) -%}
 SELECT
@@ -18,9 +18,9 @@ SELECT
 FROM
   {{ src_table }}
 {{ dbt_datavault.filter_and_incremental_code(src) }}
-{% endfor %}
+{%- endfor -%}
 {% endcall -%}
-{% endmacro %}
+{% endmacro -%}
 
 {% macro validate_satellite_metadata(metadata) -%}
 {% set msg = "Satellite metadata lacks " -%}


### PR DESCRIPTION
Adding new parameter to override natural_keys for hub_key and removing. For instance where natural_key needs padding etc in hub_key but not as natural_key.

{% set metadata_yaml -%}
target: 
  hub_key: test_key
  natural_keys: ['test_id']
sources:
  - type: source
    name: src_test
    table: test
    hub_key: ['test_id|| ''|'' || ''test''']
    natural_keys: ['test_id']
    load_dts: load_dts
    rec_src: test
    filter: '1=1'
{%- endset %}

{{- dbt_datavault.hub(metadata_yaml) }}

SELECT
  test_key
  ,test_id
  ,load_dts
  ,rec_src
FROM (
  SELECT
    q.*
    ,ROW_NUMBER() OVER(PARTITION BY test_key ORDER BY load_dts ASC) rn
  FROM (
    SELECT
      CAST(test_id || '|' || 'test' AS VARCHAR2(4000)) AS test_key
      ,test_id AS test_id
      ,load_dtsAS load_dts
      ,'test' AS rec_src
    FROM
      src_test.test
    WHERE
      1=1
) q  
)
WHERE rn = 1
