### PR TITLE
Dispatched pattern for make_key Oracle

### DIFF
--- a/macros/make_key.sql
+++ b/macros/make_key.sql
@@ -1,4 +1,9 @@
 {% macro make_key(ids) -%}
+    {{ return(adapter.dispatch('make_key','dbt_datavault')(ids)) }}
+{%- endmacro %}
+
+
+{% macro default__make_key(ids) -%}
     {% set strs = [] -%}
     {% for str in ids -%}
         {%- do strs.append(
@@ -11,4 +16,20 @@
 
     {% endfor -%}
     CAST({{ dbt.concat(strs) }} AS {{ dbt.type_string() }})
+{%- endmacro %}
+
+
+{% macro oracle__make_key(ids) -%}
+    {% set strs = [] -%}
+    {% for str in ids -%}
+        {%- do strs.append(
+            "CAST(" ~ str ~ " AS VARCHAR2(256 CHAR))"
+        ) -%}
+
+        {%- if not loop.last %}
+            {%- do strs.append("'|'") -%}
+        {%- endif -%} 
+
+    {% endfor -%}
+    CAST({{ dbt.concat(strs) }} AS VARCHAR2(256 CHAR))
 {%- endmacro %}


### PR DESCRIPTION
Adding dispatched pattern for make_key for Oracle. This due to lack on length coming to creating index on columns. Hardcoded to cast columns to VARCHAR2(256 CHAR).