### PR TITLE
Adding optional deduplication functionality for satellites

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,8 @@ sources:
 | target | describes columnes in the generated data vault object | X |
 |  hub_key | the name of the hub key | X |
 |  attributes | a list of the attributes of the satellite | X |
+|  no_deduplication | default `false`. if `true` removes the deduplication on target  |  |
+|  deduplicate_include | a list of fields to be included in deduplication. Overrides normal behavior where all fields will be added.  |  |
 | sources | a list of meta data for each source table for the satellite | X |
 |  name | if the source is a DBT source then it must have a name field (`source(name, table)`) |   |
 |  table | the table part of a `source(name, table)` or a `ref(table)` | X |

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ sources:
 |  hub_key | the name of the hub key | X |
 |  attributes | a list of the attributes of the satellite | X |
 |  no_deduplication | default `false`. if `true` removes the deduplication on target  |  |
-|  deduplicate_include | a list of fields to be included in deduplication. Overrides normal behavior where all fields will be added.  |  |
+|  deduplication_include | a list of fields to be included in deduplication. Overrides normal behavior where all fields will be added.  |  |
 | sources | a list of meta data for each source table for the satellite | X |
 |  name | if the source is a DBT source then it must have a name field (`source(name, table)`) |   |
 |  table | the table part of a `source(name, table)` or a `ref(table)` | X |

--- a/macros/deduplicate.sql
+++ b/macros/deduplicate.sql
@@ -1,5 +1,4 @@
-{% macro deduplicate(dedup_fields, return_fields=None, order_field='load_dts', no_deduplication=false, deduplication_include=false) -%}
-{%- if deduplication_include %}{% set dedup_fields = deduplication_include %}{% endif %}
+{% macro deduplicate(dedup_fields, return_fields=None, order_field='load_dts', no_deduplication=false) -%}
 {% if no_deduplication -%}
 {{- caller() }}
 {% else -%}

--- a/macros/deduplicate.sql
+++ b/macros/deduplicate.sql
@@ -1,4 +1,4 @@
-{% macro deduplicate(dedup_fields, return_fields=None, order_field='load_dts', no_deduplication=false, deduplicate_include=false) -%}
+{% macro deduplicate(dedup_fields, return_fields=None, order_field='load_dts', no_deduplication=false, deduplication_include=false) -%}
 {% if no_deduplication -%}
 {{- caller() }}
 {% else -%}
@@ -24,14 +24,14 @@ FROM (
     FROM
       {{ this }} t
     WHERE
-      {%- if deduplicate_include -%}
-      {%- for include in deduplicate_include -%}
+      {%- if deduplication_include %}
+      {%- for include in deduplication_include %}
       t.{{ include }} = q.{{ include }}
       {%- endfor -%} 
-      {% else -%}
+      {%- else -%}
       {%- for dedup_field in dedup_fields %}
       COALESCE(CAST(t.{{ dedup_field }} AS {{ dbt.type_string() }}), '#') = COALESCE(CAST(q.{{ dedup_field }} AS {{ dbt.type_string() }}), '#'){% if not loop.last %} AND{% endif %}
-      {%- endfor %}
+      {%- endfor -%}
       {%- endif %}   
   )
   {%- endif %}  

--- a/macros/deduplicate.sql
+++ b/macros/deduplicate.sql
@@ -1,5 +1,5 @@
 {% macro deduplicate(dedup_fields, return_fields=None, order_field='load_dts', no_deduplication=false, deduplication_include=false) -%}
-{% if deduplication_include %}{% set dedup_fields = deduplication_include %}{% endif %}
+{%- if deduplication_include %}{% set dedup_fields = deduplication_include %}{% endif %}
 {% if no_deduplication -%}
 {{- caller() }}
 {% else -%}

--- a/macros/deduplicate.sql
+++ b/macros/deduplicate.sql
@@ -1,4 +1,5 @@
 {% macro deduplicate(dedup_fields, return_fields=None, order_field='load_dts', no_deduplication=false, deduplication_include=false) -%}
+{% if deduplication_include %}{% set dedup_fields = deduplication_include %}{% endif %}
 {% if no_deduplication -%}
 {{- caller() }}
 {% else -%}
@@ -24,15 +25,9 @@ FROM (
     FROM
       {{ this }} t
     WHERE
-      {%- if deduplication_include %}
-      {%- for include in deduplication_include %}
-      t.{{ include }} = q.{{ include }}{% if not loop.last %} AND{% endif %}
-      {%- endfor -%} 
-      {%- else -%}
       {%- for dedup_field in dedup_fields %}
       COALESCE(CAST(t.{{ dedup_field }} AS {{ dbt.type_string() }}), '#') = COALESCE(CAST(q.{{ dedup_field }} AS {{ dbt.type_string() }}), '#'){% if not loop.last %} AND{% endif %}
       {%- endfor -%}
-      {%- endif %}   
   )
   {%- endif %}  
 )

--- a/macros/deduplicate.sql
+++ b/macros/deduplicate.sql
@@ -26,7 +26,7 @@ FROM (
     WHERE
       {%- if deduplication_include %}
       {%- for include in deduplication_include %}
-      t.{{ include }} = q.{{ include }}
+      t.{{ include }} = q.{{ include }}{% if not loop.last %} AND{% endif %}
       {%- endfor -%} 
       {%- else -%}
       {%- for dedup_field in dedup_fields %}

--- a/macros/satellite.sql
+++ b/macros/satellite.sql
@@ -4,7 +4,7 @@
 {%- set tgt = metadata.target -%}
 {% set all_fields = [tgt.hub_key, 'load_dts'] + tgt.attributes + ['rec_src'] -%}
 
-{% call dbt_datavault.deduplicate([tgt.hub_key] + tgt.attributes, all_fields, no_deduplication=tgt.no_deduplication, deduplicate_include=tgt.deduplicate_include) -%}
+{% call dbt_datavault.deduplicate([tgt.hub_key] + tgt.attributes, all_fields, no_deduplication=tgt.no_deduplication, deduplication_include=tgt.deduplication_include) -%}
 {%- for src in metadata.sources -%}
 {% if not loop.first %}UNION ALL{% endif %}
 {% set src_table = source(src.name, src.table) if src.name else ref(src.table) -%}

--- a/macros/satellite.sql
+++ b/macros/satellite.sql
@@ -4,7 +4,8 @@
 {%- set tgt = metadata.target -%}
 {% set all_fields = [tgt.hub_key, 'load_dts'] + tgt.attributes + ['rec_src'] -%}
 
-{% call dbt_datavault.deduplicate([tgt.hub_key] + tgt.attributes, all_fields, no_deduplication=tgt.no_deduplication, deduplication_include=tgt.deduplication_include) -%}
+{% set dedup_fields = tgt.deduplication_include if tgt.deduplication_include else [tgt.hub_key] + tgt.attributes %}
+{% call dbt_datavault.deduplicate(dedup_fields, all_fields, no_deduplication=tgt.no_deduplication) -%}
 {%- for src in metadata.sources -%}
 {% if not loop.first %}UNION ALL{% endif %}
 {% set src_table = source(src.name, src.table) if src.name else ref(src.table) -%}

--- a/macros/satellite.sql
+++ b/macros/satellite.sql
@@ -4,7 +4,7 @@
 {%- set tgt = metadata.target -%}
 {% set all_fields = [tgt.hub_key, 'load_dts'] + tgt.attributes + ['rec_src'] -%}
 
-{% call dbt_datavault.deduplicate([tgt.hub_key] + tgt.attributes, all_fields, no_deduplication=tgt.no_deduplication) -%}
+{% call dbt_datavault.deduplicate([tgt.hub_key] + tgt.attributes, all_fields, no_deduplication=tgt.no_deduplication, deduplicate_include=tgt.deduplicate_include) -%}
 {%- for src in metadata.sources -%}
 {% if not loop.first %}UNION ALL{% endif %}
 {% set src_table = source(src.name, src.table) if src.name else ref(src.table) -%}


### PR DESCRIPTION
Adding functionality to override the default settings of the deduplication for satellites. It makes it possible to specify a list of fields that target should be deduplicated towards.

Normal behavior of deduplication for a target satellite is to include all attributes from target excl load_dts and rec_src.

```
{% set metadata_yaml -%}
target: 
  hub_key: customer_key
  attributes: ['effective_ts', 'firstname', 'lastname', 'middlename']
  deduplication_include: ['customer_key', 'effective_ts']
sources:
  - name: datalake
    table: customer
    natural_keys: [ssn]
    attributes: ['date', 'name', 'lastname', middlename]
    load_dts: ingestion_time
    rec_src: datalake.sales
{%- endset %}
```